### PR TITLE
fix all textures on mobs to work on latest minetest on windows and all versions on linux

### DIFF
--- a/cyst.lua
+++ b/cyst.lua
@@ -15,7 +15,7 @@ mobs:register_mob("livingnether:cyst", {
 	mesh = "Cyst.b3d",
 	visual_size = {x = 1.0, y = 1.0},
 	textures = {
-		{"texturecyst.png"},
+		{"texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png","texturecyst.png"},
 	},
 	sounds = {
 		damage = "livingnether_cyst",

--- a/flyingrod.lua
+++ b/flyingrod.lua
@@ -14,7 +14,7 @@ stepheight = 3,
 	mesh = "Flyingrod.b3d",
 	visual_size = {x = 1.0, y = 1.0},
 	textures = {
-		{"textureflyingrod.png"},
+		{"textureflyingrod.png","textureflyingrod.png","textureflyingrod.png","textureflyingrod.png","textureflyingrod.png","textureflyingrod.png","textureflyingrod.png","textureflyingrod.png","textureflyingrod.png","textureflyingrod.png","textureflyingrod.png","textureflyingrod.png","textureflyingrod.png","textureflyingrod.png"},
 	},
 	sounds = {
 		random = "livingnether_flyingrod",

--- a/lavawalker.lua
+++ b/lavawalker.lua
@@ -14,7 +14,7 @@ stepheight = 4,
 	mesh = "Lavawalker.b3d",
 	visual_size = {x = 1.0, y = 1.0},
 	textures = {
-		{"texturelavawalker.png"},
+		{"texturelavawalker.png","texturelavawalker.png","texturelavawalker.png","texturelavawalker.png","texturelavawalker.png","texturelavawalker.png","texturelavawalker.png","texturelavawalker.png","texturelavawalker.png","texturelavawalker.png","texturelavawalker.png","texturelavawalker.png","texturelavawalker.png","texturelavawalker.png",},
 	},
 	sounds = {
 		random = "livingnether_lavawalker",

--- a/noodlemaster.lua
+++ b/noodlemaster.lua
@@ -20,7 +20,7 @@ collisionbox = {-3,-1.0,-3,3,3,3},
 	mesh = "Noodlemaster.b3d",
 	visual_size = {x = 4.0, y = 4.0},
 	textures = {
-		{"texturenoodlemaster.png"},
+		{"texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png","texturenoodlemaster.png",},
 	},
 	sounds = {
 		death = "livingnether_noodlemaster",

--- a/razorback.lua
+++ b/razorback.lua
@@ -14,7 +14,7 @@ stepheight = 2,
 	mesh = "Razorback.b3d",
 	visual_size = {x = 1.0, y = 1.0},
 	textures = {
-		{"texturerazorback.png"},
+		{"texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png","texturerazorback.png"},
 	},
 	sounds = {
 		random = "livingnether_razorback",

--- a/sokaarcher.lua
+++ b/sokaarcher.lua
@@ -18,7 +18,7 @@ mobs:register_mob("livingnether:sokaarcher", {
 	mesh = "Sokaarcher.b3d",
 	drawtype = "front",
 	textures = {
-		{"texturesokaarcher.png"},
+		{"texturesokaarcher.png","texturesokaarcher.png","texturesokaarcher.png","texturesokaarcher.png","texturesokaarcher.png","texturesokaarcher.png","texturesokaarcher.png","texturesokaarcher.png","texturesokaarcher.png","texturesokaarcher.png","texturesokaarcher.png","texturesokaarcher.png","texturesokaarcher.png","texturesokaarcher.png","texturesokaarcher.png"},
 	},
 	visual_size = {x=1, y=1},
 	-- sounds

--- a/sokameele.lua
+++ b/sokameele.lua
@@ -13,7 +13,7 @@ mobs:register_mob("livingnether:sokameele", {
 	mesh = "Sokameele.b3d",
 	visual_size = {x = 1.0, y = 1.0},
 	textures = {
-		{"texturesokameele.png"},
+		{"texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png","texturesokameele.png"},
 	},
 	sounds = {
 		attack = "livingnether_sokameele3",

--- a/tardigrade.lua
+++ b/tardigrade.lua
@@ -15,7 +15,7 @@ mobs:register_mob("livingnether:tardigrade", {
 	visual = "mesh",
 	mesh = "Tardigrade.b3d",
 	textures = {
-		{"texturetardigrade.png"},
+		{"texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png","texturetardigrade.png",},
 	},
 	makes_footstep_sound = true,
 	sounds = {

--- a/whip.lua
+++ b/whip.lua
@@ -14,7 +14,7 @@ mobs:register_mob("livingnether:whip", {
 	mesh = "Whip.b3d",
 	visual_size = {x = 1.0, y = 1.0},
 	textures = {
-		{"texturewhip.png"},
+		{"texturewhip.png","texturewhip.png","texturewhip.png","texturewhip.png","texturewhip.png"},
 	},
 	sounds = {
 		attack = "livingnether_whip", 


### PR DESCRIPTION
The fix is to have at least as many textures in the textures table as there are unique blender objects in the model